### PR TITLE
opcode: remove checkoutput

### DIFF
--- a/script/src/opcode.rs
+++ b/script/src/opcode.rs
@@ -213,8 +213,6 @@ pub enum Opcode {
 
     // More Ops
     OP_TYPE = 0xd0,
-    OP_CHECKOUTPUT = 0xd1,
-    OP_CHECKOUTPUTVERIFY = 0xd2,
 
     // Custom
     OP_INVALIDOPCODE = 0xff,


### PR DESCRIPTION
Removes two opcodes (`OP_CHECKOUTPUT`, `OP_CHECKOUTPUTVERIFY`) that were removed from Handshake consensus in https://github.com/handshake-org/hsd/commit/580a9b22860b567b4bfc10e26c277c1a8dbc3de4.

